### PR TITLE
fix: mask API key input and correct repo URL in docs

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -6,8 +6,8 @@ This guide provides step-by-step instructions for using the MAKER framework in y
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/maker_framework.git
-   cd maker_framework
+   git clone https://github.com/bigdegenenergy/maker-framework.git
+   cd maker-framework
    ```
 
 2. Install dependencies:

--- a/maker_cli.py
+++ b/maker_cli.py
@@ -5,6 +5,7 @@ MAKER Framework Interactive CLI
 Simple interface for users to input their task and let MAKER handle the rest.
 """
 
+import getpass
 import os
 import sys
 from typing import Optional
@@ -44,7 +45,7 @@ def get_api_key() -> Optional[str]:
         
         choice = input("\nEnter API key now? (y/n): ").strip().lower()
         if choice == 'y':
-            api_key = input("API Key: ").strip()
+            api_key = getpass.getpass("API Key: ").strip()
         else:
             print("\n❌ Cannot proceed without API key. Exiting.")
             return None


### PR DESCRIPTION
Use getpass to hide API key during interactive entry, and fix placeholder username/repo name in USAGE.md to match actual repository.